### PR TITLE
Renamed package because it was already taken in pypi. namespace stays…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ is provided by code that been generated from a model of the service.
 
 ## Install from pypi
 ```
-pip install awsiot
+pip install awsiotsdk
 ```
 
 ## Build from source

--- a/continuous-delivery/test_prod_pypi.yml
+++ b/continuous-delivery/test_prod_pypi.yml
@@ -19,7 +19,7 @@ phases:
       - echo Build started on `date`
       - cd aws-iot-device-sdk-python-v2 
       - CURRENT_TAG_VERSION=$(git describe --abbrev=0)
-      - python3 -m pip install --user awsiot==$CURRENT_TAG_VERSION
+      - python3 -m pip install --user awsiotsdk==$CURRENT_TAG_VERSION
       - python3 samples/basic_discovery.py --region us-east-1 --cert /tmp/certificate.pem --key /tmp/privatekey.pem --ca_file /tmp/AmazonRootCA1.pem --thing_name aws-sdk-crt-unit-test --print_discover_resp_only -v Trace
 
   post_build:

--- a/continuous-delivery/test_test_pypi.yml
+++ b/continuous-delivery/test_test_pypi.yml
@@ -21,7 +21,7 @@ phases:
       - CURRENT_TAG_VERSION=$(git describe --abbrev=0)
       # this is here because typing isn't in testpypi, so pull it from prod instead
       - python3 -m pip install typing
-      - python3 -m pip install -i https://testpypi.python.org/simple --user awsiot==$CURRENT_TAG_VERSION
+      - python3 -m pip install -i https://testpypi.python.org/simple --user awsiotsdk==$CURRENT_TAG_VERSION
       - python3 samples/basic_discovery.py --region us-east-1 --cert /tmp/certificate.pem --key /tmp/privatekey.pem --ca_file /tmp/AmazonRootCA1.pem --thing_name aws-sdk-crt-unit-test --print_discover_resp_only -v Trace
 
   post_build:

--- a/continuous-delivery/test_version_exists
+++ b/continuous-delivery/test_version_exists
@@ -4,7 +4,7 @@ set -e
 git describe --abbrev=0
 #now get the tag
 CURRENT_TAG_VERSION=$(git describe --abbrev=0)
-if pip install -vvv awsiot==$CURRENT_TAG_VERSION; then
+if pip install -vvv awsiotsdk==$CURRENT_TAG_VERSION; then
     echo "$CURRENT_TAG_VERSION is already in pypi, cut a new tag if you want to upload another version."
     exit 1
 fi

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='awsiot',
-    version='0.2.3',
+    name='awsiotsdk',
+    version='0.2.4',
     description='AWS IoT SDK based on the AWS Common Runtime',
     author='AWS SDK Common Runtime Team',
     url='https://github.com/awslabs/aws-iot-device-sdk-python-v2',


### PR DESCRIPTION
… the same, since it's not uncommon to leave off 'sdk' from a namespace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
