### PR TITLE
use latest awscrt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,7 @@ This SDK is built on the AWS Common Runtime, a collection of libraries
 [4](https://github.com/awslabs/aws-c-http),
 [5](https://github.com/awslabs/aws-c-cal) ...) written in C to be
 cross-platform, high-performance, secure, and reliable. The libraries are bound
-to Python by the [awscrt](https://github.com/awslabs/aws-crt-python) package.
-
-The awscrt package can be installed via. pip 
-```
-pip install awscrt
-```
+to Python by the `awscrt` package ([PyPI](https://pypi.org/project/awscrt/)) ([Github](https://github.com/awslabs/aws-crt-python)).
 
 Integration with AWS IoT Services such as
 [Device Shadow](https://docs.aws.amazon.com/iot/latest/developerguide/iot-device-shadows.html)
@@ -32,12 +27,12 @@ is provided by code that been generated from a model of the service.
 ## Minimum Requirements
 *   Python 3.5+ or Python 2.7+
 
-## Install from pypi
+## Install from PyPI
 ```
 pip install awsiotsdk
 ```
 
-## Build from source
+## Install from source
 ```
 pip install ./aws-iot-device-sdk-python-v2
 ```
@@ -275,7 +270,7 @@ and receive.
 
 ## basic discovery
 
-This sample intended for use directly with the 
+This sample intended for use directly with the
 [Getting Started with AWS IoT Greengrass](https://docs.aws.amazon.com/greengrass/latest/developerguide/gg-gs.html) guide.
 
 # License

--- a/awsiot/__init__.py
+++ b/awsiot/__init__.py
@@ -124,10 +124,10 @@ class MqttServiceClient(object):
                 `callback`. The dict comes from parsing the received
                 message as JSON.
 
-        Returns two values. The first is a `Future` which will contain a result
-        of `awscrt.mqtt.QoS` when the server has acknowledged the subscription,
-        or an exception if the subscription fails. The second value is a topic
-        which may be passed to `unsubscribe()` to stop receiving messages.
+        Returns two values. The first is a `Future` whose result will be the
+        `awscrt.mqtt.QoS` granted by the server, or an exception if the
+        subscription fails. The second value is a topic which may be passed to
+        `unsubscribe()` to stop receiving messages.
         Note that messages may arrive before the subscription is acknowledged.
         """
 

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -121,8 +121,8 @@ if args.mode == 'both' or args.mode == 'subscribe':
         print('Publish received on topic {}'.format(topic))
         print(message)
 
-    subscribe_future = mqtt_connection.subscribe(args.topic, QoS.AT_MOST_ONCE, on_publish)
-    subscribe_future[0].result()
+    subscribe_future, _ = mqtt_connection.subscribe(args.topic, QoS.AT_MOST_ONCE, on_publish)
+    subscribe_result = subscribe_future.result()
 
 loop_count = 0
 while loop_count < args.max_pub_ops:

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -81,8 +81,8 @@ def on_connection_resumed(connection, error_code, session_present):
     print('connection resumed with error {}, session present {}'.format(error_code, session_present))
 
 
-# Try endpoints until we find one that works
-def connect_to_greengrass():
+# Try IoT endpoints until we find one that works
+def try_iot_endpoints():
     for gg_group in discover_response.gg_groups:
 
         gg_core_tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(args.certificate_path, args.private_key_path)
@@ -113,7 +113,7 @@ def connect_to_greengrass():
 
     exit('All connection attempts failed')
 
-mqtt_connection = connect_to_greengrass()
+mqtt_connection = try_iot_endpoints()
 
 if args.mode == 'both' or args.mode == 'subscribe':
 

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -63,18 +63,14 @@ tls_context = io.ClientTlsContext(tls_options)
 socket_options = io.SocketOptions()
 socket_options.connect_timeout_ms = 3000
 
+print('Performing greengrass discovery...')
 discovery_client = DiscoveryClient(client_bootstrap, socket_options, tls_context, args.region)
 resp_future = discovery_client.discover(args.thing_name)
-resp = resp_future.result()
+discover_response = resp_future.result()
 
+print(discover_response)
 if args.print_discover_resp_only:
-    print(resp)
     exit(0)
-
-gg_core_tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(args.certificate_path, args.private_key_path)
-gg_core_tls_options.override_default_trust_store(bytes(resp.gg_groups[0].certificate_authorities[0], encoding='utf-8'))
-gg_core_tls_ctx = io.ClientTlsContext(gg_core_tls_options)
-mqtt_client = Client(client_bootstrap, gg_core_tls_ctx)
 
 
 def on_connection_interupted(connection, error_code):
@@ -85,27 +81,44 @@ def on_connection_resumed(connection, error_code, session_present):
     print('connection resumed with error {}, session present {}'.format(error_code, session_present))
 
 
-mqtt_connection = Connection(mqtt_client, on_connection_interrupted=on_connection_interupted, on_connection_resumed=on_connection_resumed)
+# Try endpoints until we find one that works
+def connect_to_greengrass():
+    for gg_group in discover_response.gg_groups:
 
-connection_succeeded = False
-for conectivity_info in resp.gg_groups[0].cores[0].connectivity:
-    try:
-        connect_future = mqtt_connection.connect(args.thing_name, resp.gg_groups[0].cores[0].connectivity[0].host_address, resp.gg_groups[0].cores[0].connectivity[0].port, clean_session=False)
-        connect_future.result()
-        connection_succeeded = True
-        break
-    except Exception as e:
-        print('connection failed with exception {}'.format(e))
-        continue
+        gg_core_tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(args.certificate_path, args.private_key_path)
+        gg_core_tls_options.override_default_trust_store(bytes(gg_group.certificate_authorities[0], encoding='utf-8'))
+        gg_core_tls_ctx = io.ClientTlsContext(gg_core_tls_options)
+        mqtt_client = Client(client_bootstrap, gg_core_tls_ctx)
 
-if connection_succeeded != True:
-    print('All connection attempts for core {} failed'.format(resp.gg_groups[0].cores[0].thing_arn))
-    exit(-1)
+        for gg_core in gg_group.cores:
+            for connectivity_info in gg_core.connectivity:
+                try:
+                    print('Trying core {} at host {} port {}'.format(gg_core.thing_arn, connectivity_info.host_address, connectivity_info.port))
+                    mqtt_connection = Connection(
+                        mqtt_client,
+                        on_connection_interrupted=on_connection_interupted,
+                        on_connection_resumed=on_connection_resumed)
+                    connect_future = mqtt_connection.connect(
+                        client_id=args.thing_name,
+                        host_name=connectivity_info.host_address,
+                        port=connectivity_info.port,
+                        clean_session=False)
+                    connect_future.result()
+                    print('Connected!')
+                    return mqtt_connection
+
+                except Exception as e:
+                    print('Connection failed with exception {}'.format(e))
+                    continue
+
+    exit('All connection attempts failed')
+
+mqtt_connection = connect_to_greengrass()
 
 if args.mode == 'both' or args.mode == 'subscribe':
 
     def on_publish(topic, message):
-        print('publish recieved on topic {}'.format(topic))
+        print('Publish received on topic {}'.format(topic))
         print(message)
 
     subscribe_future = mqtt_connection.subscribe(args.topic, QoS.AT_MOST_ONCE, on_publish)

--- a/samples/basic_discovery.py
+++ b/samples/basic_discovery.py
@@ -50,7 +50,7 @@ elif args.verbosity.lower() == 'info':
     io.init_logging(LogLevel.Info, 'stderr')
 elif args.verbosity.lower() == 'debug':
     io.init_logging(LogLevel.Debug, 'stderr')
-elif args.verbosity.lower() == 'trace':    
+elif args.verbosity.lower() == 'trace':
     io.init_logging(LogLevel.Trace, 'stderr')
 
 event_loop_group = io.EventLoopGroup(1)
@@ -77,18 +77,18 @@ gg_core_tls_ctx = io.ClientTlsContext(gg_core_tls_options)
 mqtt_client = Client(client_bootstrap, gg_core_tls_ctx)
 
 
-def on_connection_interupted(error_code):
+def on_connection_interupted(connection, error_code):
     print('connection interupted with error {}'.format(error_code))
 
 
-def on_connection_resumed(error_code, session_present):
+def on_connection_resumed(connection, error_code, session_present):
     print('connection resumed with error {}, session present {}'.format(error_code, session_present))
 
 
 mqtt_connection = Connection(mqtt_client, on_connection_interrupted=on_connection_interupted, on_connection_resumed=on_connection_resumed)
 
 connection_succeeded = False
-for conectivity_info in resp.gg_groups[0].cores[0].connectivity:    
+for conectivity_info in resp.gg_groups[0].cores[0].connectivity:
     try:
         connect_future = mqtt_connection.connect(args.thing_name, resp.gg_groups[0].cores[0].connectivity[0].host_address, resp.gg_groups[0].cores[0].connectivity[0].port, clean_session=False)
         connect_future.result()
@@ -96,7 +96,7 @@ for conectivity_info in resp.gg_groups[0].cores[0].connectivity:
         break
     except Exception as e:
         print('connection failed with exception {}'.format(e))
-        continue  
+        continue
 
 if connection_succeeded != True:
     print('All connection attempts for core {} failed'.format(resp.gg_groups[0].cores[0].thing_arn))
@@ -121,6 +121,6 @@ while loop_count < args.max_pub_ops:
         pub_future = mqtt_connection.publish(args.topic, messageJson, QoS.AT_MOST_ONCE)
         pub_future[0].result()
         print('Published topic {}: {}\n'.format(args.topic, messageJson))
-       
+
         loop_count += 1
     time.sleep(1)

--- a/samples/jobs.py
+++ b/samples/jobs.py
@@ -230,7 +230,7 @@ if __name__ == '__main__':
 
     tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(args.cert, args.key)
     if args.root_ca:
-        tls_options.override_default_trust_store_from_path(ca_path=None, ca_file=args.root_ca)
+        tls_options.override_default_trust_store_from_path(ca_dirpath=None, ca_filepath=args.root_ca)
     tls_context = io.ClientTlsContext(tls_options)
 
     mqtt_client = mqtt.Client(client_bootstrap, tls_context)

--- a/samples/pubsub.py
+++ b/samples/pubsub.py
@@ -108,7 +108,7 @@ if __name__ == '__main__':
         port = port,
         use_websocket=False,
         clean_session=True,
-        keep_alive=5) # DO NOT COMMIT THIS CHANGE
+        keep_alive=6000)
 
     # Future.result() waits until a result is available
     connect_future.result()
@@ -122,9 +122,7 @@ if __name__ == '__main__':
         callback=on_message_received)
 
     subscribe_result = subscribe_future.result()
-    if subscribe_result['qos'] is None:
-        raise RuntimeError("Server rejected subscription")
-    print("Subscribed!")
+    print("Subscribed with {}".format(str(subscribe_result['qos'])))
 
     # Publish message to server desired number of times.
     # This step is skipped if message is blank.

--- a/samples/shadow.py
+++ b/samples/shadow.py
@@ -235,7 +235,7 @@ if __name__ == '__main__':
 
     tls_options = io.TlsContextOptions.create_client_with_mtls_from_path(args.cert, args.key)
     if args.root_ca:
-        tls_options.override_default_trust_store_from_path(ca_path=None, ca_file=args.root_ca)
+        tls_options.override_default_trust_store_from_path(ca_dirpath=None, ca_filepath=args.root_ca)
     tls_context = io.ClientTlsContext(tls_options)
 
     mqtt_client = mqtt.Client(client_bootstrap, tls_context)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='awsiotsdk',
-    version='0.2.9',
+    version='0.3.0',
     description='AWS IoT SDK based on the AWS Common Runtime',
     author='AWS SDK Common Runtime Team',
     url='https://github.com/awslabs/aws-iot-device-sdk-python-v2',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     url='https://github.com/awslabs/aws-iot-device-sdk-python-v2',
     packages = ['awsiot'],
     install_requires=[
-        'awscrt==0.3.0',
+        'awscrt==0.3.1',
         'futures;python_version<"3.2"',
         'typing;python_version<"3.5"',
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,11 @@ setup(
     description='AWS IoT SDK based on the AWS Common Runtime',
     author='AWS SDK Common Runtime Team',
     url='https://github.com/awslabs/aws-iot-device-sdk-python-v2',
-    packages = find_packages(),
+    packages = ['awsiot'],
     install_requires=[
-        'awscrt==0.2.16',
-        'futures; python_version == "2.7"',
-        'typing; python_version <= "3.4"',
+        'awscrt==0.3.0',
+        'futures;python_version<"3.2"',
+        'typing;python_version<"3.5"',
     ],
     python_requires='>=2.7',
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name='awsiotsdk',
@@ -23,7 +23,7 @@ setup(
     url='https://github.com/awslabs/aws-iot-device-sdk-python-v2',
     packages = ['awsiot'],
     install_requires=[
-        'awscrt==0.3.1',
+        'awscrt==0.3.3',
         'futures;python_version<"3.2"',
         'typing;python_version<"3.5"',
     ],


### PR DESCRIPTION
Update to `awscrt` 0.3.1

Adapt to API changes:
- HTTP API:
  - had an extreme makeover, but that only affects the implementation of Greengrass Discovery, not its API.
- MQTT API:
  - The Future returned by `subscribe()` now contains a `QoS`. It used to contain `None`.
  - `on_connection_interrupted` and `on_connection_resumed` callbacks have an extra `connection` argument.
- IO API:
  - `override_default_trust_store_from_path()` arguments renamed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
